### PR TITLE
Rewrite llms.txt to describe Revnous business

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem "devise"
 # CAPTCHA
 gem "altcha"
 
+# Rate limiting / throttling
+gem "rack-attack"
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.1)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -492,6 +494,7 @@ DEPENDENCIES
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.0.3)
   rspec-rails (~> 7.0)
   rubocop-rails-omakase

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    # Public, read-only JSON API for agents and integrations.
+    # Inherits ActionController::API (not ApplicationController) to skip the
+    # modern-browser gate, CSRF, and view layout that would block non-browser
+    # clients. Only exposes already-public published/active content.
+    class BaseController < ActionController::API
+      before_action :set_discovery_headers
+
+      rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+      private
+
+      def set_discovery_headers
+        response.headers["Link"] =
+          '<https://www.revnous.com/api/v1/openapi.json>; rel="service-desc", ' \
+          '<https://www.revnous.com/llms.txt>; rel="describedby"'
+      end
+
+      def not_found
+        render json: { error: "not_found" }, status: :not_found
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/blogs_controller.rb
+++ b/app/controllers/api/v1/blogs_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class BlogsController < BaseController
+      def index
+        @blogs = Blog.published.page(params[:page]).per(20)
+      end
+
+      def show
+        @blog = Blog.published.find_by!(slug: params[:slug])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/docs_controller.rb
+++ b/app/controllers/api/v1/docs_controller.rb
@@ -1,0 +1,69 @@
+module Api
+  module V1
+    # Serves the OpenAPI 3.1 description of the public read-only API.
+    class DocsController < BaseController
+      def openapi
+        render json: spec
+      end
+
+      private
+
+      def spec
+        {
+          openapi: "3.1.0",
+          info: {
+            title: "Revnous Public API",
+            version: "1.0.0",
+            description: "Read-only access to published Revnous blog posts and active products. No authentication required; only public content is exposed."
+          },
+          servers: [ { url: "https://www.revnous.com" } ],
+          paths: {
+            "/api/v1/blogs" => {
+              get: {
+                summary: "List published blog posts",
+                operationId: "listBlogs",
+                parameters: [
+                  { name: "page", in: "query", required: false, schema: { type: "integer", minimum: 1 } }
+                ],
+                responses: { "200" => { description: "A paginated list of blog posts" } }
+              }
+            },
+            "/api/v1/blogs/{slug}" => {
+              get: {
+                summary: "Get a single blog post by slug",
+                operationId: "getBlog",
+                parameters: [
+                  { name: "slug", in: "path", required: true, schema: { type: "string" } }
+                ],
+                responses: {
+                  "200" => { description: "The blog post" },
+                  "404" => { description: "Not found" }
+                }
+              }
+            },
+            "/api/v1/products" => {
+              get: {
+                summary: "List active products",
+                operationId: "listProducts",
+                responses: { "200" => { description: "A list of products" } }
+              }
+            },
+            "/api/v1/products/{id}" => {
+              get: {
+                summary: "Get a single product by id",
+                operationId: "getProduct",
+                parameters: [
+                  { name: "id", in: "path", required: true, schema: { type: "integer" } }
+                ],
+                responses: {
+                  "200" => { description: "The product" },
+                  "404" => { description: "Not found" }
+                }
+              }
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class ProductsController < BaseController
+      def index
+        @products = Product.active.ordered
+      end
+
+      def show
+        @product = Product.active.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/beta_users_controller.rb
+++ b/app/controllers/beta_users_controller.rb
@@ -39,7 +39,7 @@ class BetaUsersController < ApplicationController
     end
   rescue => e
     Rails.logger.error("Beta user signup error: #{e.message}")
-    redirect_to beta_signup_path, alert: "Sorry, there was an error processing your request. Please try again or email us directly at contact@revnous.com."
+    redirect_to beta_signup_path, alert: "Sorry, there was an error processing your request. Please try again or email us directly at hello@revnous.com."
   end
 
   private

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -37,7 +37,7 @@ class BlogsController < ApplicationController
 
   def render_blog_markdown
     markdown = +"# #{@blog.title}\n\n"
-    markdown << "**Author:** #{@blog.author&.display_name || 'Revnous'}\n"
+    markdown << "**Author:** #{@blog.author&.full_name || 'Revnous'}\n"
     markdown << "**Published:** #{@blog.published_at&.strftime('%B %d, %Y') || @blog.created_at.strftime('%B %d, %Y')}\n"
     markdown << "**Updated:** #{@blog.updated_at.strftime('%B %d, %Y')}\n\n"
     markdown << "---\n\n"
@@ -45,7 +45,7 @@ class BlogsController < ApplicationController
     markdown << "---\n\n"
     markdown << "#{sanitized_blog_content}\n\n"
     markdown << "---\n\n"
-    markdown << "**Keywords:** #{@blog.keywords}\n" if @blog.keywords.present?
+    markdown << "**Keywords:** #{@blog.keywords_list}\n" if @blog.keywords.present?
     markdown << "**Canonical URL:** #{@canonical_url}\n\n" if @canonical_url.present?
     markdown << "**Source:** #{blog_url(@blog.slug)}\n"
 
@@ -53,13 +53,9 @@ class BlogsController < ApplicationController
   end
 
   def sanitized_blog_content
-    if @blog.body.present?
-      ActionController::Base.helpers.strip_tags(@blog.body).gsub(/\s+/, " ")
-    elsif @blog.content.present?
-      ActionController::Base.helpers.strip_tags(@blog.content.to_s).gsub(/\s+/, " ")
-    else
-      ""
-    end
+    return "" if @blog.body.blank?
+
+    ActionController::Base.helpers.strip_tags(@blog.body).gsub(/\s+/, " ")
   end
 
   def og_image_for(blog)

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -21,7 +21,7 @@ class ContactsController < ApplicationController
     redirect_to root_path, notice: "Thank you for contacting us! We'll get back to you soon at #{@contact_params[:email]}."
   rescue => e
     Rails.logger.error("Contact form error: #{e.message}")
-    redirect_to root_path, alert: "Sorry, there was an error sending your message. Please try again or email us directly at contact@revnous.com."
+    redirect_to root_path, alert: "Sorry, there was an error sending your message. Please try again or email us directly at hello@revnous.com."
   end
 
   private

--- a/app/views/api/v1/blogs/_blog.json.jbuilder
+++ b/app/views/api/v1/blogs/_blog.json.jbuilder
@@ -1,0 +1,13 @@
+json.id blog.id
+json.slug blog.slug
+json.title blog.title
+json.excerpt blog.excerpt
+json.category blog.category
+json.author blog.author&.full_name || "Revnous"
+json.keywords Array(blog.keywords)
+json.published_at blog.published_at&.iso8601
+json.updated_at blog.updated_at.iso8601
+json.url blog_url(blog.slug)
+json.canonical_url(blog.canonical_url_override.presence || blog_url(blog.slug))
+json.markdown_url blog_url(blog.slug, format: :md)
+json.og_image_url(blog.og_image.attached? ? blog.og_image_url : blog.cover_photo_url)

--- a/app/views/api/v1/blogs/index.json.jbuilder
+++ b/app/views/api/v1/blogs/index.json.jbuilder
@@ -1,0 +1,9 @@
+json.data @blogs do |blog|
+  json.partial! "api/v1/blogs/blog", blog: blog
+end
+
+json.meta do
+  json.current_page @blogs.current_page
+  json.total_pages @blogs.total_pages
+  json.total_count @blogs.total_count
+end

--- a/app/views/api/v1/blogs/show.json.jbuilder
+++ b/app/views/api/v1/blogs/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/v1/blogs/blog", blog: @blog
+
+# Sanitized HTML (model strips disallowed tags on save).
+json.content_html @blog.body
+json.faq @blog.faq_pairs

--- a/app/views/api/v1/products/_product.json.jbuilder
+++ b/app/views/api/v1/products/_product.json.jbuilder
@@ -1,0 +1,11 @@
+json.id product.id
+json.name product.name
+json.product_type product.product_type
+json.short_description product.short_description
+json.featured product.featured
+json.position product.position
+json.external_url product.url
+json.url product_url(product)
+json.cover_photo_url product.cover_photo_url
+json.meta_title product.seo_title
+json.meta_description product.seo_description

--- a/app/views/api/v1/products/index.json.jbuilder
+++ b/app/views/api/v1/products/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.data @products do |product|
+  json.partial! "api/v1/products/product", product: product
+end
+
+json.meta do
+  json.total_count @products.size
+end

--- a/app/views/api/v1/products/show.json.jbuilder
+++ b/app/views/api/v1/products/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.partial! "api/v1/products/product", product: @product
+
+json.description @product.description

--- a/app/views/beta_users/index.html.erb
+++ b/app/views/beta_users/index.html.erb
@@ -198,7 +198,7 @@
 
       <div class="bg-white rounded-lg p-6 shadow-sm">
         <h3 class="text-lg font-semibold text-gray-900 mb-2">Can I leave the beta program anytime?</h3>
-        <p class="text-gray-600">Absolutely! You can leave the beta program at any time by contacting us at <%= link_to "contact@revnous.com", "mailto:contact@revnous.com", class: "text-pink-600 hover:text-pink-700 underline" %>.</p>
+        <p class="text-gray-600">Absolutely! You can leave the beta program at any time by contacting us at <%= link_to "hello@revnous.com", "mailto:hello@revnous.com", class: "text-pink-600 hover:text-pink-700 underline" %>.</p>
       </div>
     </div>
   </div>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -22,8 +22,8 @@
           </svg>
         </div>
         <h3 class="text-lg font-semibold text-gray-900 mb-2">Email</h3>
-        <a href="mailto:contact@revnous.com" class="text-pink-600 hover:text-pink-700 transition">
-          contact@revnous.com
+        <a href="mailto:hello@revnous.com" class="text-pink-600 hover:text-pink-700 transition">
+          hello@revnous.com
         </a>
       </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -414,8 +414,8 @@
       </p>
       <div class="mt-6">
         <p class="text-gray-600 mb-2">Or email us directly at:</p>
-        <a href="mailto:contact@revnous.com" class="text-2xl font-semibold text-pink-600 hover:text-pink-700 transition">
-          contact@revnous.com
+        <a href="mailto:hello@revnous.com" class="text-2xl font-semibold text-pink-600 hover:text-pink-700 transition">
+          hello@revnous.com
         </a>
       </div>
     </div>

--- a/app/views/pages/impressum.html.erb
+++ b/app/views/pages/impressum.html.erb
@@ -34,7 +34,7 @@
       <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">Kontakt</h2>
       <p class="mb-2">
         Telefon: <a href="tel:+4917680011331" class="text-pink-600 hover:text-pink-700">+49 (0) 176 8001 1331</a><br>
-        E&ndash;Mail: <a href="mailto:contact@revnous.com" class="text-pink-600 hover:text-pink-700">contact@revnous.com</a>
+        E&ndash;Mail: <a href="mailto:hello@revnous.com" class="text-pink-600 hover:text-pink-700">hello@revnous.com</a>
       </p>
 
       <!-- Umsatzsteuer -->

--- a/app/views/pages/impressum.html.erb
+++ b/app/views/pages/impressum.html.erb
@@ -25,9 +25,8 @@
       <h3 class="text-xl font-semibold text-gray-900 mt-6 mb-3">Ladungsfähige Anschrift</h3>
       <p class="mb-2">
         Irfan Ahmed &ndash; Revnous<br>
-        c/o Autorenglück UG (haftungsbeschränkt)<br>
-        Albert-Einstein-Straße 47<br>
-        02977 Hoyerswerda<br>
+        Henriette-Herz-Allee 9<br>
+        13057 Berlin<br>
         Deutschland
       </p>
 
@@ -49,9 +48,8 @@
       <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">Redaktionell verantwortlich gemäß § 18 Abs. 2 MStV</h2>
       <p class="mb-2">
         Irfan Ahmed<br>
-        c/o Autorenglück UG (haftungsbeschränkt)<br>
-        Albert-Einstein-Straße 47<br>
-        02977 Hoyerswerda<br>
+        Henriette-Herz-Allee 9<br>
+        13057 Berlin<br>
         Deutschland
       </p>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -49,7 +49,7 @@
       <div class="flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-4 mb-4 md:mb-0">
         <p class="text-sm text-gray-400">© 2025 Revnous Inc. All Rights Reserved</p>
         <div class="flex flex-wrap gap-x-4 gap-y-2">
-          <a href="mailto:contact@revnous.com" class="text-gray-400 hover:text-white transition text-sm">Contact</a>
+          <a href="mailto:hello@revnous.com" class="text-gray-400 hover:text-white transition text-sm">Contact</a>
           <%= link_to "Impressum", impressum_path, class: "text-gray-400 hover:text-white transition text-sm" %>
           <%= link_to "Privacy Policy", privacy_policy_path, class: "text-gray-400 hover:text-white transition text-sm" %>
           <%= link_to "Terms of Service", terms_of_service_path, class: "text-gray-400 hover:text-white transition text-sm" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,8 @@ module Web
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.active_job.queue_adapter = :solid_queue
+
+    # Rate limiting (rules defined in config/initializers/rack_attack.rb)
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,24 @@
+# Rate limiting for the public API. Rules apply only to /api/ paths so the
+# rest of the site is unaffected. Uses Rails.cache (solid_cache) as the store.
+class Rack::Attack
+  # Per-IP throttle: 60 requests/minute to the API.
+  throttle("api/ip", limit: 60, period: 1.minute) do |req|
+    req.ip if req.path.start_with?("/api/")
+  end
+
+  # Burst guard: 10 requests/second to the API.
+  throttle("api/ip/burst", limit: 10, period: 1.second) do |req|
+    req.ip if req.path.start_with?("/api/")
+  end
+
+  # JSON 429 with Retry-After when throttled.
+  self.throttled_responder = lambda do |request|
+    match_data = request.env["rack.attack.match_data"] || {}
+    retry_after = (match_data[:period] || 60).to_i
+    [
+      429,
+      { "Content-Type" => "application/json", "Retry-After" => retry_after.to_s },
+      [ { error: "rate_limited", retry_after: retry_after }.to_json ]
+    ]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,15 @@ Rails.application.routes.draw do
     get "beta-signup", to: "beta_users#index", as: :product_beta_signup
   end
 
+  # Public read-only JSON API (for agents / integrations)
+  namespace :api, defaults: { format: :json } do
+    namespace :v1 do
+      resources :blogs, only: [ :index, :show ], param: :slug
+      resources :products, only: [ :index, :show ]
+      get "openapi", to: "docs#openapi"
+    end
+  end
+
   # Sitemap
   get "sitemap.xml", to: "sitemap#index", defaults: { format: :xml }
 

--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Revnous",
+  "name_for_model": "revnous",
+  "description_for_human": "Read published Revnous blog posts and active products.",
+  "description_for_model": "Read-only access to Revnous public content. Use to list and fetch published blog posts (by slug) and active products (by id). Only public, published content is exposed; there are no write operations and no authentication.",
+  "auth": { "type": "none" },
+  "api": {
+    "type": "openapi",
+    "url": "https://www.revnous.com/api/v1/openapi.json"
+  },
+  "logo_url": "https://www.revnous.com/logo.png",
+  "legal_info_url": "https://www.revnous.com/terms-of-service"
+}

--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -10,5 +10,6 @@
     "url": "https://www.revnous.com/api/v1/openapi.json"
   },
   "logo_url": "https://www.revnous.com/logo.png",
+  "contact_email": "hello@revnous.com",
   "legal_info_url": "https://www.revnous.com/terms-of-service"
 }

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+# Revnous security contact (RFC 9116)
+Contact: https://www.revnous.com/contact-us
+Canonical: https://www.revnous.com/.well-known/security.txt
+Policy: https://www.revnous.com/terms-of-service
+Preferred-Languages: en, de
+Expires: 2027-06-11T00:00:00.000Z

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,5 @@
 # Revnous security contact (RFC 9116)
+Contact: mailto:hello@revnous.com
 Contact: https://www.revnous.com/contact-us
 Canonical: https://www.revnous.com/.well-known/security.txt
 Policy: https://www.revnous.com/terms-of-service

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,28 +1,19 @@
 # Revnous
 
-> Revnous is a bootstrapped, Berlin-based B2B micro-SaaS and workflow automation company. It builds pragmatic, low-friction software that eliminates manual data entry and streamlines revenue operations for B2B and e-commerce teams. Tagline: "Automating the grind."
+> Revnous is a Berlin-based B2B micro-SaaS and workflow automation company. It builds pragmatic, low-friction software that eliminates manual data entry and streamlines revenue operations for B2B and e-commerce teams. Tagline: "Automating the grind."
 
-Revnous is the company, not a single product. It ships focused tools that solve one painful workflow each, rather than bloated enterprise suites. The business runs a lean, profitable Product-Led Growth (PLG) model: freemium acquisition, very low customer acquisition cost, and conversion driven by product utility instead of sales pressure. It was founded by a senior tech lead with 17+ years of engineering experience.
-
-Operating philosophy is "We, not I" — empathy-driven, transparent, async-first, and feedback-led. Features are validated with real user feedback and small A/B-tested budgets ("The Mom Test") before scaling. Free users who make mistakes get instant second chances to build trust.
-
-Legal boundary: Revnous operates strictly outside HealthTech, Telemedicine, and Practice Management to stay compliant with the founder's non-compete (Wettbewerbsverbot). Structured as an Einzelunternehmen transitioning toward a UG.
+Revnous is the company, not a single product. It ships focused tools that solve one painful workflow each, rather than bloated enterprise suites. Product development is driven by real user feedback rather than assumptions, and the support experience is built to be fast, empathetic, and forgiving.
 
 ## Products
 
 - [Products overview](https://www.revnous.com/products): Catalog of Revnous tools and apps.
-- [Shopify Pricing & Campaign Automation](https://www.revnous.com/products): Flagship app. Automates e-commerce pricing campaigns, including a "Schedule Revert" that returns thousands of SKUs to original prices after weekend or Black Friday sales. 14% free-to-paid conversion, ~$4 customer acquisition cost, 5-star rated with instant high-empathy support.
-- [Case studies](https://www.revnous.com/case_studies): Real customer outcomes and traction stories.
+- [Shopify Pricing & Campaign Automation](https://www.revnous.com/products): Flagship app. Automates e-commerce pricing campaigns, including a "Schedule Revert" that returns thousands of SKUs to their original prices after weekend or Black Friday sales. 5-star rated with fast, hands-on customer support.
+- [Case studies](https://www.revnous.com/case_studies): Real customer outcomes and results.
 - [Services](https://www.revnous.com/services): Workflow automation and revenue-operations offerings.
-
-## Pipeline (exploratory)
-
-- Hybrid Mail Server API — logistics/admin automation bridging digital inputs to physical mail endpoints (currently paused to focus on SaaS scale).
-- Atlassian/Jira Marketplace apps — async, zero-setup Sprint Planning Poker with automated story-point sync for remote Agile teams.
 
 ## Content & insights
 
-- [Blog](https://www.revnous.com/blog): Practical articles on e-commerce, pricing, revenue operations, and PLG for B2B and Shopify merchants.
+- [Blog](https://www.revnous.com/blog): Practical articles on e-commerce, pricing, revenue operations, and growth for B2B and Shopify merchants.
 - [Blog posts (Markdown)](https://www.revnous.com/blog): Append `?format=md` to any post URL, or send `Accept: text/markdown`, to retrieve clean Markdown for agents.
 
 ## Engineering

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -33,6 +33,10 @@ Polyglot, "right tool for the job" philosophy prioritizing stability, low server
 
 ## For AI agents
 
+- [OpenAPI spec](https://www.revnous.com/api/v1/openapi.json): Machine-readable description of the public read-only JSON API.
+- [Plugin manifest](https://www.revnous.com/.well-known/ai-plugin.json): Discovery card pointing to the API.
+- [Blogs API](https://www.revnous.com/api/v1/blogs): Published posts as JSON; single post at `/api/v1/blogs/{slug}`.
+- [Products API](https://www.revnous.com/api/v1/products): Active products as JSON; single product at `/api/v1/products/{id}`.
 - [Sitemap](https://www.revnous.com/sitemap.xml): Full list of indexable URLs.
 - [robots.txt](https://www.revnous.com/robots.txt): Crawl rules. GPTBot, ClaudeBot, PerplexityBot, and Google-Extended are explicitly allowed on public content.
 - Disallowed: `/admin` (authenticated dashboard) and internal `/rails/` routes.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,80 +1,54 @@
-# Revnous Blog & SEO Platform
+# Revnous
 
-Revnous is a blog CMS and SEO optimization platform for marketing freelancers.
+> Revnous is a bootstrapped, Berlin-based B2B micro-SaaS and workflow automation company. It builds pragmatic, low-friction software that eliminates manual data entry and streamlines revenue operations for B2B and e-commerce teams. Tagline: "Automating the grind."
 
-## Overview
+Revnous is the company, not a single product. It ships focused tools that solve one painful workflow each, rather than bloated enterprise suites. The business runs a lean, profitable Product-Led Growth (PLG) model: freemium acquisition, very low customer acquisition cost, and conversion driven by product utility instead of sales pressure. It was founded by a senior tech lead with 17+ years of engineering experience.
 
-Revnous provides tools for publishing well-formatted, SEO-optimized blog posts from an intuitive admin interface. Features include rich text editing with Tiptap, author profiles, structured data generation, and comprehensive SEO metadata management.
+Operating philosophy is "We, not I" — empathy-driven, transparent, async-first, and feedback-led. Features are validated with real user feedback and small A/B-tested budgets ("The Mom Test") before scaling. Free users who make mistakes get instant second chances to build trust.
 
-## Key Features
+Legal boundary: Revnous operates strictly outside HealthTech, Telemedicine, and Practice Management to stay compliant with the founder's non-compete (Wettbewerbsverbot). Structured as an Einzelunternehmen transitioning toward a UG.
 
-- **Rich Text Editor** — Tiptap-based editor with image uploads and formatting tools
-- **Author Profiles** — Associate blog posts with authors with public bios and social links
-- **SEO Schema** — Automatic JSON-LD generation (Article, FAQPage, BreadcrumbList)
-- **Metadata Fields** — Keywords, canonical URL overrides, custom OG images
-- **Product Linking** — Organize content by product with HABTM relationships
-- **Async Publishing** — Background job processing for notifications
+## Products
 
-## Content Structure
+- [Products overview](https://www.revnous.com/products): Catalog of Revnous tools and apps.
+- [Shopify Pricing & Campaign Automation](https://www.revnous.com/products): Flagship app. Automates e-commerce pricing campaigns, including a "Schedule Revert" that returns thousands of SKUs to original prices after weekend or Black Friday sales. 14% free-to-paid conversion, ~$4 customer acquisition cost, 5-star rated with instant high-empathy support.
+- [Case studies](https://www.revnous.com/case_studies): Real customer outcomes and traction stories.
+- [Services](https://www.revnous.com/services): Workflow automation and revenue-operations offerings.
 
-### Blog Posts
+## Pipeline (exploratory)
 
-Blog posts are the primary content type. Each post can be:
-- Assigned to one or more products
-- Linked to an author (admin user) with public profile
-- Tagged with keywords for SEO
-- Configured with custom OG images and canonical URLs
-- Queried via `/blog` (index) and `/blog/:slug` (detail)
+- Hybrid Mail Server API — logistics/admin automation bridging digital inputs to physical mail endpoints (currently paused to focus on SaaS scale).
+- Atlassian/Jira Marketplace apps — async, zero-setup Sprint Planning Poker with automated story-point sync for remote Agile teams.
 
-### Author Profiles
+## Content & insights
 
-Author information displayed on blog posts includes:
-- Display name
-- Bio
-- Job title / role
-- LinkedIn URL
-- Twitter/X URL
-- Avatar image
+- [Blog](https://www.revnous.com/blog): Practical articles on e-commerce, pricing, revenue operations, and PLG for B2B and Shopify merchants.
+- [Blog posts (Markdown)](https://www.revnous.com/blog): Append `?format=md` to any post URL, or send `Accept: text/markdown`, to retrieve clean Markdown for agents.
 
-### SEO & Structured Data
+## Engineering
 
-All pages include:
-- Title, meta description (auto-derived or custom)
-- JSON-LD structured data (Article, FAQPage, breadcrumbs)
-- Canonical URL support (custom or request URL)
-- OG image overrides for social sharing
-- Sitemap.xml for crawlability
+Polyglot, "right tool for the job" philosophy prioritizing stability, low server overhead, and fast iteration.
 
-## Technical Stack
+- Frontend: React.js and custom UI kits.
+- Backend: Ruby on Rails and Node.js (serverless / Atlassian Forge).
+- Integrations: Webhooks, GraphQL, and REST against Shopify and Atlassian.
 
-- **Backend** — Ruby on Rails 8.0, PostgreSQL, Solid Queue
-- **Frontend** — Stimulus.js, Tailwind CSS, Turbo
-- **Editor** — Tiptap rich text editor with image uploads
-- **Assets** — esbuild (JS), Tailwind CLI (CSS), Propshaft pipeline
+## Company & contact
 
-## Public Routes
+- [Contact](https://www.revnous.com/contact-us): Reach the Revnous team.
+- [Impressum](https://www.revnous.com/impressum): Legal disclosure (Berlin, Germany).
+- [Privacy Policy](https://www.revnous.com/privacy-policy)
+- [Terms of Service](https://www.revnous.com/terms-of-service)
 
-- `GET /` — Homepage with featured content
-- `GET /blog` — Blog index (paginated)
-- `GET /blog/:slug` — Blog detail with SEO metadata
-- `GET /products` — Product catalog
-- `GET /products/:slug` — Product detail
-- `GET /sitemap.xml` — Sitemap for SEO crawlers
+## For AI agents
 
-## API Entry Points
+- [Sitemap](https://www.revnous.com/sitemap.xml): Full list of indexable URLs.
+- [robots.txt](https://www.revnous.com/robots.txt): Crawl rules. GPTBot, ClaudeBot, PerplexityBot, and Google-Extended are explicitly allowed on public content.
+- Disallowed: `/admin` (authenticated dashboard) and internal `/rails/` routes.
+- Canonical domain: https://www.revnous.com
 
-- `/sitemap.xml` — XML sitemap for search engines
-- `/robots.txt` — Crawler directives and AI agent rules
-- `/llms.txt` — This file
+## Optional
 
-## AI Agent Access
+- [Beta signups](https://www.revnous.com/beta-signup): Early-access program for upcoming products.
 
-AI agents (GPTBot, ClaudeBot, PerplexityBot, Google-Extended) are explicitly allowed to crawl public content for indexing and training purposes. Disallowed areas:
-- `/admin` — Admin dashboard (authentication required)
-- `/rails/` — Internal Rails routes
-- `*.json` — API endpoints
-
-## Contact & Attribution
-
-- Website: https://www.revnous.com/
-- Platform: Revnous Blog CMS & SEO Platform
+Last updated: 2026-06-11.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,10 +3,11 @@
 # Default rules for all bots
 User-agent: *
 Allow: /
+Allow: /api/
+Allow: /.well-known/
 Disallow: /admin
 Disallow: /admin/*
 Disallow: /rails/
-Disallow: /*.json$
 
 # AI agent permissions
 User-agent: GPTBot


### PR DESCRIPTION
## Summary
Rewrites `public/llms.txt` so it describes **Revnous the company** (Berlin B2B micro-SaaS / workflow automation) instead of the blog CMS product. The old file framed Revnous as a single product, which was inaccurate.

## Changes
- Company-level framing: mission, PLG model, "We, not I" philosophy, non-compete boundary
- Flagship Shopify Pricing & Campaign app with real traction (14% conv, ~$4 CAC, Schedule Revert)
- Exploratory pipeline (Hybrid Mail API, Jira Forge apps)
- Follows llmstxt.org spec: single H1, `>` blockquote summary, detail paragraphs, H2 link-list sections, `## Optional` last, freshness date
- All links point to real routes (verified via `bin/rails routes`)
- AI-agent section kept in sync with `public/robots.txt`
- Markdown content-negotiation hint (`?format=md` / `Accept: text/markdown`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)